### PR TITLE
Fix hang while re-authing.

### DIFF
--- a/zk/conn_test.go
+++ b/zk/conn_test.go
@@ -1,0 +1,52 @@
+package zk
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+)
+
+func TestRecurringReAuthHang(t *testing.T) {
+	sessionTimeout := 2 * time.Second
+
+	finish := make(chan struct{})
+	defer close(finish)
+	go func() {
+		select {
+		case <-finish:
+			return
+		case <-time.After(5 * sessionTimeout):
+			panic("expected not hang")
+		}
+	}()
+
+	zkC, err := StartTestCluster(2, ioutil.Discard, ioutil.Discard)
+	if err != nil {
+		panic(err)
+	}
+	defer zkC.Stop()
+
+	conn, _, err := zkC.ConnectAll()
+	if err != nil {
+		panic(err)
+	}
+	for conn.state != StateHasSession {
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Add auth.
+	if err := conn.AddAuth("digest", []byte("test:test")); err != nil {
+		panic(err)
+	}
+
+	currentServer := conn.server
+	conn.debugCloseRecvLoop = true
+	conn.debugReauthDone = make(chan struct{})
+	zkC.StopServer(currentServer)
+	// wait connect to new zookeeper.
+	for conn.server == currentServer && conn.state != StateHasSession {
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	<-conn.debugReauthDone
+}


### PR DESCRIPTION
## 背景

当网络不好的时候，在与 Zookeeper 断开连接之后，再也无法连上。

通过 Go 的 HTTP Debug API 查看调用栈，发现处理 Zookeeper 连接的部分 Hang 在以下几个位置：
https://github.com/tevino/go-zookeeper/blob/c218ec636befdf6cdf800c0218b7131ff4de7687/zk/conn.go#L366

https://github.com/tevino/go-zookeeper/blob/c218ec636befdf6cdf800c0218b7131ff4de7687/zk/conn.go#L424

通过日志发现，当时 Recv Loop  已经结束，而 Send Loop 还在等待 re-auth 完成。

在 `resendZkAuth` 中，通过 `sendRequest` 发送 auth 请求，然后等待这次 auth 的结果，而结果是由 Recv Loop 写入的，如果在等待结果的过程中 Recv Loop 结束，那么 `resendZkAuth` 会一直等待。

代码中的 `flushRequests`  用于清理与 ZK 连接中断时依然在等待结果的请求，但是需要 Recv Loop 和 Send Loop 都结束才会执行。在上述情况中，Send Loop 在等待重新授权的结果，而重新授权的结果由 Recv Loop 写入，但此时 Recv Loop 已经结束，所以整个流程就卡住了。

## 复现步骤

1. 启动一个有多个节点的 Zookeeper 集群，并建立连接。
1. 增加 creds，保证与 ZK 重连的时候需要进行重新授权。
1. 停止当前连接的 ZK 节点，触发重连逻辑。
1. 在重连的过程中，停掉 Recv Loop。
1. 重连卡在等待 re-auth 的过程。
