### PR TITLE
Update from mesosphere/go-zookeeper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: go
 go:
   - 1.9
 
+jdk:
+  - oraclejdk9
+
 sudo: false
 
 branches:
@@ -9,12 +12,13 @@ branches:
     - master
 
 before_install:
-  - wget http://apache.claz.org/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz
+  - wget http://apache.cs.utah.edu/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz
   - tar -zxvf zookeeper*tar.gz
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
 
 script:
+  - jdk_switcher use oraclejdk9
   - go build ./...
   - go fmt ./...
   - go vet ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.7
+  - 1.9
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ branches:
     - master
 
 before_install:
-  - wget http://apache.cs.utah.edu/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz
-  - tar -zxvf zookeeper*tar.gz
+  - wget http://apache.cs.utah.edu/zookeeper/zookeeper-${zk_version}/zookeeper-${zk_version}.tar.gz
+  - tar -zxvf zookeeper*tar.gz && zip -d zookeeper-${zk_version}/contrib/fatjar/zookeeper-${zk_version}-fatjar.jar 'META-INF/*.SF' 'META-INF/*.DSA'
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
 
@@ -29,3 +29,5 @@ script:
 env:
   global:
     secure: Coha3DDcXmsekrHCZlKvRAc+pMBaQU1QS/3++3YCCUXVDBWgVsC1ZIc9df4RLdZ/ncGd86eoRq/S+zyn1XbnqK5+ePqwJoUnJ59BE8ZyHLWI9ajVn3fND1MTduu/ksGsS79+IYbdVI5wgjSgjD3Ktp6Y5uPl+BPosjYBGdNcHS4=
+  matrix:
+    - zk_version=3.4.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,8 @@ script:
   - go vet ./...
   - go test -i -race ./...
   - go test -race -covermode atomic -coverprofile=profile.cov ./zk
-  - goveralls -coverprofile=profile.cov -service=travis-ci
+    #  - goveralls -coverprofile=profile.cov -service=travis-ci
 
 env:
-  global:
-    secure: Coha3DDcXmsekrHCZlKvRAc+pMBaQU1QS/3++3YCCUXVDBWgVsC1ZIc9df4RLdZ/ncGd86eoRq/S+zyn1XbnqK5+ePqwJoUnJ59BE8ZyHLWI9ajVn3fND1MTduu/ksGsS79+IYbdVI5wgjSgjD3Ktp6Y5uPl+BPosjYBGdNcHS4=
   matrix:
     - zk_version=3.4.10

--- a/examples/basic.go
+++ b/examples/basic.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/samuel/go-zookeeper/zk"
+	"github.com/tevino/go-zookeeper/zk"
 )
 
 func main() {

--- a/zk/cluster_test.go
+++ b/zk/cluster_test.go
@@ -75,8 +75,7 @@ func TestClientClusterFailover(t *testing.T) {
 	tc.StopServer(hasSessionEvent1.Server)
 
 	// Wait for the session to be reconnected with the new leader.
-	hasSessionWatcher2.Wait(8 * time.Second)
-	if hasSessionWatcher2 == nil {
+	if hasSessionWatcher2.Wait(8*time.Second) == nil {
 		t.Fatalf("Failover failed")
 	}
 

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -279,6 +279,16 @@ func WithMaxBufferSize(maxBufferSize int) connOption {
 	}
 }
 
+// WithMaxConnBufferSize sets maximum buffer size used to send and encode
+// packets to Zookeeper server. The standard Zookeepeer client for java defaults
+// to a limit of 1mb. This option should be used for non-standard server setup
+// where znode is bigger than default 1mb.
+func WithMaxConnBufferSize(maxBufferSize int) connOption {
+       return func(c *Conn) {
+               c.buf = make([]byte, maxBufferSize)
+       }
+}
+
 func (c *Conn) Close() {
 	close(c.shouldQuit)
 

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -906,12 +906,20 @@ func (c *Conn) AddAuth(scheme string, auth []byte) error {
 }
 
 func (c *Conn) Children(path string) ([]string, *Stat, error) {
+	if err := validatePath(path); err != nil {
+		return nil, nil, err
+	}
+
 	res := &getChildren2Response{}
 	_, err := c.request(opGetChildren2, &getChildren2Request{Path: path, Watch: false}, res, nil)
 	return res.Children, &res.Stat, err
 }
 
 func (c *Conn) ChildrenW(path string) ([]string, *Stat, <-chan Event, error) {
+	if err := validatePath(path); err != nil {
+		return nil, nil, nil, err
+	}
+
 	var ech <-chan Event
 	res := &getChildren2Response{}
 	_, err := c.request(opGetChildren2, &getChildren2Request{Path: path, Watch: true}, res, func(req *request, res *responseHeader, err error) {
@@ -926,6 +934,10 @@ func (c *Conn) ChildrenW(path string) ([]string, *Stat, <-chan Event, error) {
 }
 
 func (c *Conn) Get(path string) ([]byte, *Stat, error) {
+	if err := validatePath(path); err != nil {
+		return nil, nil, err
+	}
+
 	res := &getDataResponse{}
 	_, err := c.request(opGetData, &getDataRequest{Path: path, Watch: false}, res, nil)
 	return res.Data, &res.Stat, err
@@ -933,6 +945,10 @@ func (c *Conn) Get(path string) ([]byte, *Stat, error) {
 
 // GetW returns the contents of a znode and sets a watch
 func (c *Conn) GetW(path string) ([]byte, *Stat, <-chan Event, error) {
+	if err := validatePath(path); err != nil {
+		return nil, nil, nil, err
+	}
+
 	var ech <-chan Event
 	res := &getDataResponse{}
 	_, err := c.request(opGetData, &getDataRequest{Path: path, Watch: true}, res, func(req *request, res *responseHeader, err error) {
@@ -947,15 +963,20 @@ func (c *Conn) GetW(path string) ([]byte, *Stat, <-chan Event, error) {
 }
 
 func (c *Conn) Set(path string, data []byte, version int32) (*Stat, error) {
-	if path == "" {
-		return nil, ErrInvalidPath
+	if err := validatePath(path); err != nil {
+		return nil, err
 	}
+
 	res := &setDataResponse{}
 	_, err := c.request(opSetData, &SetDataRequest{path, data, version}, res, nil)
 	return &res.Stat, err
 }
 
 func (c *Conn) Create(path string, data []byte, flags int32, acl []ACL) (string, error) {
+	if err := validatePath(path); err != nil {
+		return "", err
+	}
+
 	res := &createResponse{}
 	_, err := c.request(opCreate, &CreateRequest{path, data, acl, flags}, res, nil)
 	return res.Path, err
@@ -966,6 +987,10 @@ func (c *Conn) Create(path string, data []byte, flags int32, acl []ACL) (string,
 // ephemeral node still exists. Therefore, on reconnect we need to check if a node
 // with a GUID generated on create exists.
 func (c *Conn) CreateProtectedEphemeralSequential(path string, data []byte, acl []ACL) (string, error) {
+	if err := validatePath(path); err != nil {
+		return "", err
+	}
+
 	var guid [16]byte
 	_, err := io.ReadFull(rand.Reader, guid[:16])
 	if err != nil {
@@ -1007,11 +1032,19 @@ func (c *Conn) CreateProtectedEphemeralSequential(path string, data []byte, acl 
 }
 
 func (c *Conn) Delete(path string, version int32) error {
+	if err := validatePath(path); err != nil {
+		return err
+	}
+
 	_, err := c.request(opDelete, &DeleteRequest{path, version}, &deleteResponse{}, nil)
 	return err
 }
 
 func (c *Conn) Exists(path string) (bool, *Stat, error) {
+	if err := validatePath(path); err != nil {
+		return false, nil, err
+	}
+
 	res := &existsResponse{}
 	_, err := c.request(opExists, &existsRequest{Path: path, Watch: false}, res, nil)
 	exists := true
@@ -1023,6 +1056,10 @@ func (c *Conn) Exists(path string) (bool, *Stat, error) {
 }
 
 func (c *Conn) ExistsW(path string) (bool, *Stat, <-chan Event, error) {
+	if err := validatePath(path); err != nil {
+		return false, nil, nil, err
+	}
+
 	var ech <-chan Event
 	res := &existsResponse{}
 	_, err := c.request(opExists, &existsRequest{Path: path, Watch: true}, res, func(req *request, res *responseHeader, err error) {
@@ -1044,17 +1081,29 @@ func (c *Conn) ExistsW(path string) (bool, *Stat, <-chan Event, error) {
 }
 
 func (c *Conn) GetACL(path string) ([]ACL, *Stat, error) {
+	if err := validatePath(path); err != nil {
+		return nil, nil, err
+	}
+
 	res := &getAclResponse{}
 	_, err := c.request(opGetAcl, &getAclRequest{Path: path}, res, nil)
 	return res.Acl, &res.Stat, err
 }
 func (c *Conn) SetACL(path string, acl []ACL, version int32) (*Stat, error) {
+	if err := validatePath(path); err != nil {
+		return nil, err
+	}
+
 	res := &setAclResponse{}
 	_, err := c.request(opSetAcl, &setAclRequest{Path: path, Acl: acl, Version: version}, res, nil)
 	return &res.Stat, err
 }
 
 func (c *Conn) Sync(path string) (string, error) {
+	if err := validatePath(path); err != nil {
+		return "", err
+	}
+
 	res := &syncResponse{}
 	_, err := c.request(opSync, &syncRequest{Path: path}, res, nil)
 	return res.Path, err

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -906,7 +906,7 @@ func (c *Conn) AddAuth(scheme string, auth []byte) error {
 }
 
 func (c *Conn) Children(path string) ([]string, *Stat, error) {
-	if err := validatePath(path); err != nil {
+	if err := validatePath(path, false); err != nil {
 		return nil, nil, err
 	}
 
@@ -916,7 +916,7 @@ func (c *Conn) Children(path string) ([]string, *Stat, error) {
 }
 
 func (c *Conn) ChildrenW(path string) ([]string, *Stat, <-chan Event, error) {
-	if err := validatePath(path); err != nil {
+	if err := validatePath(path, false); err != nil {
 		return nil, nil, nil, err
 	}
 
@@ -934,7 +934,7 @@ func (c *Conn) ChildrenW(path string) ([]string, *Stat, <-chan Event, error) {
 }
 
 func (c *Conn) Get(path string) ([]byte, *Stat, error) {
-	if err := validatePath(path); err != nil {
+	if err := validatePath(path, false); err != nil {
 		return nil, nil, err
 	}
 
@@ -945,7 +945,7 @@ func (c *Conn) Get(path string) ([]byte, *Stat, error) {
 
 // GetW returns the contents of a znode and sets a watch
 func (c *Conn) GetW(path string) ([]byte, *Stat, <-chan Event, error) {
-	if err := validatePath(path); err != nil {
+	if err := validatePath(path, false); err != nil {
 		return nil, nil, nil, err
 	}
 
@@ -963,7 +963,7 @@ func (c *Conn) GetW(path string) ([]byte, *Stat, <-chan Event, error) {
 }
 
 func (c *Conn) Set(path string, data []byte, version int32) (*Stat, error) {
-	if err := validatePath(path); err != nil {
+	if err := validatePath(path, false); err != nil {
 		return nil, err
 	}
 
@@ -973,7 +973,7 @@ func (c *Conn) Set(path string, data []byte, version int32) (*Stat, error) {
 }
 
 func (c *Conn) Create(path string, data []byte, flags int32, acl []ACL) (string, error) {
-	if err := validatePath(path); err != nil {
+	if err := validatePath(path, flags&FlagSequence == FlagSequence); err != nil {
 		return "", err
 	}
 
@@ -987,7 +987,7 @@ func (c *Conn) Create(path string, data []byte, flags int32, acl []ACL) (string,
 // ephemeral node still exists. Therefore, on reconnect we need to check if a node
 // with a GUID generated on create exists.
 func (c *Conn) CreateProtectedEphemeralSequential(path string, data []byte, acl []ACL) (string, error) {
-	if err := validatePath(path); err != nil {
+	if err := validatePath(path, true); err != nil {
 		return "", err
 	}
 
@@ -1032,7 +1032,7 @@ func (c *Conn) CreateProtectedEphemeralSequential(path string, data []byte, acl 
 }
 
 func (c *Conn) Delete(path string, version int32) error {
-	if err := validatePath(path); err != nil {
+	if err := validatePath(path, false); err != nil {
 		return err
 	}
 
@@ -1041,7 +1041,7 @@ func (c *Conn) Delete(path string, version int32) error {
 }
 
 func (c *Conn) Exists(path string) (bool, *Stat, error) {
-	if err := validatePath(path); err != nil {
+	if err := validatePath(path, false); err != nil {
 		return false, nil, err
 	}
 
@@ -1056,7 +1056,7 @@ func (c *Conn) Exists(path string) (bool, *Stat, error) {
 }
 
 func (c *Conn) ExistsW(path string) (bool, *Stat, <-chan Event, error) {
-	if err := validatePath(path); err != nil {
+	if err := validatePath(path, false); err != nil {
 		return false, nil, nil, err
 	}
 
@@ -1081,7 +1081,7 @@ func (c *Conn) ExistsW(path string) (bool, *Stat, <-chan Event, error) {
 }
 
 func (c *Conn) GetACL(path string) ([]ACL, *Stat, error) {
-	if err := validatePath(path); err != nil {
+	if err := validatePath(path, false); err != nil {
 		return nil, nil, err
 	}
 
@@ -1090,7 +1090,7 @@ func (c *Conn) GetACL(path string) ([]ACL, *Stat, error) {
 	return res.Acl, &res.Stat, err
 }
 func (c *Conn) SetACL(path string, acl []ACL, version int32) (*Stat, error) {
-	if err := validatePath(path); err != nil {
+	if err := validatePath(path, false); err != nil {
 		return nil, err
 	}
 
@@ -1100,7 +1100,7 @@ func (c *Conn) SetACL(path string, acl []ACL, version int32) (*Stat, error) {
 }
 
 func (c *Conn) Sync(path string) (string, error) {
-	if err := validatePath(path); err != nil {
+	if err := validatePath(path, false); err != nil {
 		return "", err
 	}
 

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -447,7 +447,9 @@ func (c *Conn) resendZkAuth(reauthReadyChan chan struct{}) {
 
 	for _, cred := range c.creds {
 		if shouldCancel() {
-			c.logger.Printf("Cancel re-submitting credentials")
+			if c.logInfo {
+				c.logger.Printf("Cancel re-submitting credentials")
+			}
 			return
 		}
 		resChan, err := c.sendRequest(
@@ -469,10 +471,14 @@ func (c *Conn) resendZkAuth(reauthReadyChan chan struct{}) {
 		select {
 		case res = <-resChan:
 		case <-c.closeChan:
-			c.logger.Printf("Recv closed, cancel re-submitting credentials, cannot read")
+			if c.logInfo {
+				c.logger.Printf("Recv closed, cancel re-submitting credentials, cannot read")
+			}
 			return
 		case <-c.shouldQuit:
-			c.logger.Printf("Should quit, cancel re-submitting credentials")
+			if c.logInfo {
+				c.logger.Printf("Should quit, cancel re-submitting credentials")
+			}
 			return
 		}
 		if res.err != nil {

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -101,8 +101,9 @@ type Conn struct {
 	reconnectLatch   chan struct{}
 	setWatchLimit    int
 	setWatchCallback func([]*setWatchesRequest)
+
 	// Debug (for recurring re-auth hang)
-	debugCloseRecvLoop bool
+	debugCloseRecvLoop int32
 	debugReauthDone    chan struct{}
 
 	logger  Logger
@@ -192,20 +193,21 @@ func Connect(servers []string, sessionTimeout time.Duration, options ...connOpti
 
 	ec := make(chan Event, eventChanSize)
 	conn := &Conn{
-		dialer:         net.DialTimeout,
-		hostProvider:   &DNSHostProvider{},
-		conn:           nil,
-		state:          StateDisconnected,
-		eventChan:      ec,
-		shouldQuit:     make(chan struct{}),
-		connectTimeout: 1 * time.Second,
-		sendChan:       make(chan *request, sendChanSize),
-		requests:       make(map[int32]*request),
-		watchers:       make(map[watchPathType][]chan Event),
-		passwd:         emptyPassword,
-		logger:         DefaultLogger,
-		logInfo:        true, // default is true for backwards compatability
-		buf:            make([]byte, bufferSize),
+		dialer:          net.DialTimeout,
+		hostProvider:    &DNSHostProvider{},
+		conn:            nil,
+		state:           StateDisconnected,
+		eventChan:       ec,
+		shouldQuit:      make(chan struct{}),
+		connectTimeout:  1 * time.Second,
+		sendChan:        make(chan *request, sendChanSize),
+		requests:        make(map[int32]*request),
+		watchers:        make(map[watchPathType][]chan Event),
+		passwd:          emptyPassword,
+		logger:          DefaultLogger,
+		logInfo:         true, // default is true for backwards compatability
+		buf:             make([]byte, bufferSize),
+		debugReauthDone: make(chan struct{}),
 	}
 
 	// Set provided options.
@@ -300,7 +302,7 @@ func WithMaxBufferSize(maxBufferSize int) connOption {
 }
 
 // WithMaxConnBufferSize sets maximum buffer size used to send and encode
-// packets to Zookeeper server. The standard Zookeepeer client for java defaults
+// packets to Zookeeper server. The standard Zookeeper client for java defaults
 // to a limit of 1mb. This option should be used for non-standard server setup
 // where znode is bigger than default 1mb.
 func WithMaxConnBufferSize(maxBufferSize int) connOption {
@@ -326,6 +328,21 @@ func (c *Conn) State() State {
 // SessionID returns the current session id of the connection.
 func (c *Conn) SessionID() int64 {
 	return atomic.LoadInt64(&c.sessionID)
+}
+
+func (c *Conn) shouldDebugCloseRecvLoop() bool {
+	return (atomic.LoadInt32(&c.debugCloseRecvLoop) == 1)
+}
+
+func (c *Conn) setDebugCloseRecvLoop(v bool) {
+	var store int32
+	if v {
+		store = 1
+	} else {
+		store = 0
+	}
+
+	atomic.StoreInt32(&c.debugCloseRecvLoop, store)
 }
 
 // SetLogger sets the logger to be used for printing errors.
@@ -437,7 +454,7 @@ func (c *Conn) resendZkAuth(reauthReadyChan chan struct{}) {
 		select {
 		case res = <-resChan:
 		case <-c.closeChan:
-			c.logger.Printf("Recv closed, cancel re-submitting credentials")
+			c.logger.Printf("Recv closed, cancel re-submitting credentials, cannot read")
 			return
 		case <-c.shouldQuit:
 			c.logger.Printf("Should quit, cancel re-submitting credentials")
@@ -503,8 +520,17 @@ func (c *Conn) loop() {
 			wg.Add(1)
 			go func() {
 				<-reauthChan
-				if c.debugCloseRecvLoop {
-					close(c.debugReauthDone)
+				// This condition exists for signaling purposes, that the test
+				// `TestRecurringReAuthHang` was successful. The previous call
+				// `<-reauthChan` was not blocking. That means the
+				// `resendZkAuth` didn't block even on read loop error.
+				// See `TestRecurringReAuthHang`
+				if c.shouldDebugCloseRecvLoop() {
+					select {
+					case <-c.debugReauthDone:
+					default:
+						close(c.debugReauthDone)
+					}
 				}
 				err := c.sendLoop()
 				if err != nil || c.logInfo {
@@ -517,7 +543,11 @@ func (c *Conn) loop() {
 			wg.Add(1)
 			go func() {
 				var err error
-				if c.debugCloseRecvLoop {
+				// For purposes of testing recurring resendZkAuth we'll
+				// simulate error on read loop, which should force whole
+				// IO loop to close.
+				// See `TestRecurringReAuthHang`
+				if c.shouldDebugCloseRecvLoop() {
 					err = errors.New("DEBUG: close recv loop")
 				} else {
 					err = c.recvLoop(c.conn)

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -82,6 +82,7 @@ type Conn struct {
 	eventChan      chan Event
 	eventCallback  EventCallback // may be nil
 	shouldQuit     chan struct{}
+	shouldQuitOnce sync.Once
 	pingInterval   time.Duration
 	recvTimeout    time.Duration
 	connectTimeout time.Duration
@@ -315,12 +316,14 @@ func WithMaxConnBufferSize(maxBufferSize int) connOption {
 }
 
 func (c *Conn) Close() {
-	close(c.shouldQuit)
+	c.shouldQuitOnce.Do(func() {
+		close(c.shouldQuit)
 
-	select {
-	case <-c.queueRequest(opClose, &closeRequest{}, &closeResponse{}, nil):
-	case <-time.After(time.Second):
-	}
+		select {
+		case <-c.queueRequest(opClose, &closeRequest{}, &closeResponse{}, nil):
+		case <-time.After(time.Second):
+		}
+	})
 }
 
 // State returns the current state of the connection.
@@ -977,10 +980,30 @@ func (c *Conn) queueRequest(opcode int32, req interface{}, res interface{}, recv
 		opcode:     opcode,
 		pkt:        req,
 		recvStruct: res,
-		recvChan:   make(chan response, 1),
+		recvChan:   make(chan response, 2),
 		recvFunc:   recvFunc,
 	}
-	c.sendChan <- rq
+
+	switch opcode {
+	case opClose:
+		// always attempt to send close ops.
+		c.sendChan <- rq
+	default:
+		// otherwise avoid deadlocks for dumb clients who aren't aware that
+		// the ZK connection is closed yet.
+		select {
+		case <-c.shouldQuit:
+			rq.recvChan <- response{-1, ErrConnectionClosed}
+		case c.sendChan <- rq:
+			// check for a tie
+			select {
+			case <-c.shouldQuit:
+				// maybe the caller gets this, maybe not- we tried.
+				rq.recvChan <- response{-1, ErrConnectionClosed}
+			default:
+			}
+		}
+	}
 	return rq.recvChan
 }
 

--- a/zk/conn_test.go
+++ b/zk/conn_test.go
@@ -1,0 +1,55 @@
+package zk
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+)
+
+func TestRecurringReAuthHang(t *testing.T) {
+	sessionTimeout := 2 * time.Second
+
+	finish := make(chan struct{})
+	defer close(finish)
+	go func() {
+		select {
+		case <-finish:
+			return
+		case <-time.After(5 * sessionTimeout):
+			panic("expected not hang")
+		}
+	}()
+
+	zkC, err := StartTestCluster(2, ioutil.Discard, ioutil.Discard)
+	if err != nil {
+		panic(err)
+	}
+	defer zkC.Stop()
+
+	conn, evtC, err := zkC.ConnectAll()
+	if err != nil {
+		panic(err)
+	}
+	for conn.state != StateHasSession {
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	go func() {
+		for range evtC {
+		}
+	}()
+
+	// Add auth.
+	conn.creds = append(conn.creds, authCreds{"digest", []byte("test:test")})
+
+	currentServer := conn.server
+	conn.debugCloseRecvLoop = true
+	conn.debugReauthDone = make(chan struct{})
+	zkC.StopServer(currentServer)
+	// wait connect to new zookeeper.
+	for conn.server == currentServer && conn.state != StateHasSession {
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	<-conn.debugReauthDone
+}

--- a/zk/conn_test.go
+++ b/zk/conn_test.go
@@ -1,37 +1,35 @@
 package zk
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 	"time"
 )
 
 func TestRecurringReAuthHang(t *testing.T) {
-	sessionTimeout := 2 * time.Second
-
-	finish := make(chan struct{})
-	defer close(finish)
-	go func() {
-		select {
-		case <-finish:
-			return
-		case <-time.After(5 * sessionTimeout):
-			panic("expected not hang")
-		}
-	}()
-
 	zkC, err := StartTestCluster(3, ioutil.Discard, ioutil.Discard)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	defer zkC.Stop()
 
 	conn, evtC, err := zkC.ConnectAll()
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
+
+	ctx, cancel := context.WithDeadline(
+		context.Background(), time.Now().Add(5*time.Second))
+	defer cancel()
 	for conn.State() != StateHasSession {
 		time.Sleep(50 * time.Millisecond)
+
+		select {
+		case <-ctx.Done():
+			t.Fatal("Failed to connect to ZK")
+		default:
+		}
 	}
 
 	go func() {
@@ -47,9 +45,19 @@ func TestRecurringReAuthHang(t *testing.T) {
 	currentServer := conn.Server()
 	conn.setDebugCloseRecvLoop(true)
 	zkC.StopServer(currentServer)
+
 	// wait connect to new zookeeper.
+	ctx, cancel = context.WithDeadline(
+		context.Background(), time.Now().Add(5*time.Second))
+	defer cancel()
 	for conn.Server() == currentServer && conn.State() != StateHasSession {
 		time.Sleep(100 * time.Millisecond)
+
+		select {
+		case <-ctx.Done():
+			t.Fatal("Failed to reconnect ZK next server")
+		default:
+		}
 	}
 
 	<-conn.debugReauthDone

--- a/zk/util.go
+++ b/zk/util.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 // AuthACL produces an ACL list containing a single ACL which uses the
@@ -51,4 +52,65 @@ func stringShuffle(s []string) {
 		j := rand.Intn(i + 1)
 		s[i], s[j] = s[j], s[i]
 	}
+}
+
+// validatePath will make sure a path is valid before sending the request
+func validatePath(path string) error {
+	if path == "" {
+		return ErrInvalidPath
+	}
+
+	if path[0] != '/' {
+		return ErrInvalidPath
+	}
+
+	n := len(path)
+	if n == 1 {
+		// path is just the root
+		return nil
+	}
+
+	if path[n-1] == '/' {
+		return ErrInvalidPath
+	}
+
+	// Start at rune 1 since we already know that the first character is
+	// a '/'.
+	for i, w := 1, 0; i < n; i += w {
+		r, width := utf8.DecodeRuneInString(path[i:])
+		switch {
+		case r == '\u0000':
+			return ErrInvalidPath
+		case r == '/':
+			last, _ := utf8.DecodeLastRuneInString(path[:i])
+			if last == '/' {
+				return ErrInvalidPath
+			}
+		case r == '.':
+			last, lastWidth := utf8.DecodeLastRuneInString(path[:i])
+
+			// Check for double dot
+			if last == '.' {
+				last, _ = utf8.DecodeLastRuneInString(path[:i-lastWidth])
+			}
+
+			if last == '/' {
+				if i+1 == n {
+					return ErrInvalidPath
+				}
+
+				next, _ := utf8.DecodeRuneInString(path[i+w:])
+				if next == '/' {
+					return ErrInvalidPath
+				}
+			}
+		case r >= '\u0000' && r <= '\u001f',
+			r >= '\u007f' && r <= '\u009f',
+			r >= '\uf000' && r <= '\uf8ff',
+			r >= '\ufff0' && r < '\uffff':
+			return ErrInvalidPath
+		}
+		w = width
+	}
+	return nil
 }

--- a/zk/util.go
+++ b/zk/util.go
@@ -55,7 +55,7 @@ func stringShuffle(s []string) {
 }
 
 // validatePath will make sure a path is valid before sending the request
-func validatePath(path string) error {
+func validatePath(path string, isSequential bool) error {
 	if path == "" {
 		return ErrInvalidPath
 	}
@@ -70,7 +70,7 @@ func validatePath(path string) error {
 		return nil
 	}
 
-	if path[n-1] == '/' {
+	if !isSequential && path[n-1] == '/' {
 		return ErrInvalidPath
 	}
 

--- a/zk/util_test.go
+++ b/zk/util_test.go
@@ -16,34 +16,36 @@ func TestFormatServers(t *testing.T) {
 func TestValidatePath(t *testing.T) {
 	tt := []struct {
 		path  string
+		seq   bool
 		valid bool
 	}{
-		{"/this is / a valid/path", true},
-		{"/", true},
-		{"", false},
-		{"not/valid", false},
-		{"/ends/with/slash/", false},
-		{"/test\u0000", false},
-		{"/double//slash", false},
-		{"/single/./period", false},
-		{"/double/../period", false},
-		{"/double/..ok/period", true},
-		{"/double/alsook../period", true},
-		{"/double/period/at/end/..", false},
-		{"/name/with.period", true},
-		{"/test\u0001", false},
-		{"/test\u001f", false},
-		{"/test\u0020", true}, // first allowable
-		{"/test\u007e", true}, // last valid ascii
-		{"/test\u007f", false},
-		{"/test\u009f", false},
-		{"/test\uf8ff", false},
-		{"/test\uffef", true},
-		{"/test\ufff0", false},
+		{"/this is / a valid/path", false, true},
+		{"/", false, true},
+		{"", false, false},
+		{"not/valid", false, false},
+		{"/ends/with/slash/", false, false},
+		{"/sequential/", true, true},
+		{"/test\u0000", false, false},
+		{"/double//slash", false, false},
+		{"/single/./period", false, false},
+		{"/double/../period", false, false},
+		{"/double/..ok/period", false, true},
+		{"/double/alsook../period", false, true},
+		{"/double/period/at/end/..", false, false},
+		{"/name/with.period", false, true},
+		{"/test\u0001", false, false},
+		{"/test\u001f", false, false},
+		{"/test\u0020", false, true}, // first allowable
+		{"/test\u007e", false, true}, // last valid ascii
+		{"/test\u007f", false, false},
+		{"/test\u009f", false, false},
+		{"/test\uf8ff", false, false},
+		{"/test\uffef", false, true},
+		{"/test\ufff0", false, false},
 	}
 
 	for _, tc := range tt {
-		err := validatePath(tc.path)
+		err := validatePath(tc.path, tc.seq)
 		if (err != nil) == tc.valid {
 			t.Errorf("failed to validate path %q", tc.path)
 		}

--- a/zk/util_test.go
+++ b/zk/util_test.go
@@ -12,3 +12,40 @@ func TestFormatServers(t *testing.T) {
 		}
 	}
 }
+
+func TestValidatePath(t *testing.T) {
+	tt := []struct {
+		path  string
+		valid bool
+	}{
+		{"/this is / a valid/path", true},
+		{"/", true},
+		{"", false},
+		{"not/valid", false},
+		{"/ends/with/slash/", false},
+		{"/test\u0000", false},
+		{"/double//slash", false},
+		{"/single/./period", false},
+		{"/double/../period", false},
+		{"/double/..ok/period", true},
+		{"/double/alsook../period", true},
+		{"/double/period/at/end/..", false},
+		{"/name/with.period", true},
+		{"/test\u0001", false},
+		{"/test\u001f", false},
+		{"/test\u0020", true}, // first allowable
+		{"/test\u007e", true}, // last valid ascii
+		{"/test\u007f", false},
+		{"/test\u009f", false},
+		{"/test\uf8ff", false},
+		{"/test\uffef", true},
+		{"/test\ufff0", false},
+	}
+
+	for _, tc := range tt {
+		err := validatePath(tc.path)
+		if (err != nil) == tc.valid {
+			t.Errorf("failed to validate path %q", tc.path)
+		}
+	}
+}

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -139,6 +139,7 @@ func TestIfAuthdataSurvivesReconnect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ts.Stop()
 
 	zk, _, err := ts.ConnectAll()
 	if err != nil {


### PR DESCRIPTION
- 修复了 Watch 内容较多时，超过 ZK 包大小上限的问题
- 修复了 CI 的问题
- 增加了对操作路径的验证
- 支持设置连接 Buffer 的最大值
- 修复了 ZK 在重连时卡住的问题
- 修复了关闭连接时可能导致的死锁问题

- 优化了一个可能由于 ZK 同步的原因造成的测试失败的问题（https://travis-ci.org/tevino/go-zookeeper/builds/347658714）